### PR TITLE
Allow to define navbar menu either as a button or dropdown menu

### DIFF
--- a/_benchmarking/sl6-x86_64-gcc44.md
+++ b/_benchmarking/sl6-x86_64-gcc44.md
@@ -1,6 +1,7 @@
 ---
 title: HEP-SPEC06 Results for SL6 x86_64 (gcc 4.4)
 layout: page
+menu: SL6 x86_64 gcc44
 ---
 
 #  HEP-SPEC06 Results for SL6 x86_64 (gcc 4.4)

--- a/_benchmarking/sl7-x86_64-gcc48.md
+++ b/_benchmarking/sl7-x86_64-gcc48.md
@@ -1,6 +1,7 @@
 ---
-title: HEP-SPEC06 Results for SL7 x86_64 (gcc 4.4)
+title: HEP-SPEC06 Results for SL7 x86_64 (gcc 4.8)
 layout: page
+menu: SL7 x86_64 gcc48
 ---
 
 #  HEP-SPEC06 Results for SL7 x86_64 (gcc 4.8)

--- a/_config.yml
+++ b/_config.yml
@@ -52,8 +52,5 @@ collections:
   benchmarking:
     output: true
     permalink: /benchmarking/:title.html
-  ipv6:
-    output: true
-    permalink: /ipv6/:title.html
 
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,8 +15,20 @@
         {% for path in page_paths %}
           {% assign my_page = site.pages | where: "path", path | first %}
           {% if my_page.menu %}
-            {% if page.url == my_page.url %}
-              <li class="active"><a href="{{ my_page.url | relative_url }}">{{ my_page.menu | escape }}</a></li>
+            {% assign my_page_collection = my_page.name | replace: '.md' '' %}
+            {% if site.[my_page_collection] %}
+              <li>
+                <a class="dropdown-button" data-beloworigin="true" data-alignment="right" data-activates="{{ my_page_collection }}-menu">{{ my_page.menu }}<i class="material-icons right">arrow_drop_down</i></a>
+                <ul id="{{ my_page_collection }}-menu" class="dropdown-content">
+                  <li><a href="{{ my_page.url | relative_url }}">WG Activities</a></li>
+                  <li class="divider"></li>
+                  {% for collection_page in site.[my_page_collection] %}
+                    {% if collection_page.menu %}
+                      <li><a href="{{ collection_page.url }}">{{ collection_page.menu }}</a></li>
+                    {% endif %}
+                  {% endfor %}
+                </ul>
+              </li>
             {% else %}
   	          <li><a href="{{ my_page.url | relative_url }}">{{ my_page.menu | escape }}</a></li>
             {% endif %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -43,13 +43,36 @@
       </li>
     </ul>
   
+    {% comment %}Add class "fixed" to test on a computer/large screen{% endcomment %}
     <ul id="nav-mobile" class="side-nav">
       <li><a href="{{ "/" | relative_url }}">Home</a></li>
       {% if page_paths %}
         {% for path in page_paths %}
           {% assign my_page = site.pages | where: "path", path | first %}
           {% if my_page.menu %}
-            <li><a href="{{ my_page.url | relative_url }}">{{ my_page.menu | escape }}</a></li>
+            {% assign my_page_collection = my_page.name | replace: '.md' '' %}
+            {% if site.[my_page_collection] %}
+              <li class="no-padding">
+                <ul class="collapsible collapsible-accordion">
+                  <li>
+                    <a class="collapsible-header">{{ my_page.menu }}<i class="material-icons right">arrow_drop_down</i></a>
+                    <div class="collapsible-body">
+                      <ul>
+                        <li><a href="{{ my_page.url | relative_url }}">WG Activities</a></li>
+                        <li class="divider"></li>
+                        {% for collection_page in site.[my_page_collection] %}
+                          {% if collection_page.menu %}
+                            <li><a href="{{ collection_page.url }}">{{ collection_page.menu }}</a></li>
+                          {% endif %}
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </li>
+            {% else %}
+              <li><a href="{{ my_page.url | relative_url }}">{{ my_page.menu | escape }}</a></li>
+            {% endif %}
           {% endif %}
         {% endfor %}
       {% endif %}

--- a/_sass/materialize/components/_dropdown.scss
+++ b/_sass/materialize/components/_dropdown.scss
@@ -35,7 +35,7 @@
     }
 
     & > a, & > span {
-      font-size: 16px;
+      font-size: $dropdown-item-font-size;
       color: $dropdown-color;
       display: block;
       line-height: 22px;

--- a/_sass/materialize/components/_variables.scss
+++ b/_sass/materialize/components/_variables.scss
@@ -148,6 +148,7 @@ $dropdown-bg-color: #fff !default;
 $dropdown-hover-bg-color: #eee !default;
 $dropdown-color: $secondary-color !default;
 $dropdown-content-min-width: 100px !default;
+$dropdown-item-font-size: 16px !default;
 $dropdown-item-height: 50px !default;
 
 

--- a/assets/materialize.scss
+++ b/assets/materialize.scss
@@ -2,8 +2,10 @@
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
 
-$dropdown-content-min-width: 150px;
+$dropdown-content-min-width: 160px;
 $dropdown-item-height: 30px;
+// Ideally the same as $navbar-font-size
+$dropdown-item-font-size: 1rem;
 
 $h1-fontsize: 3.56rem;
 $h2-fontsize: 2.92rem;


### PR DESCRIPTION
To make navigation easier for WG with several pages, the navbar menu is transformed as a dropdown menu if there is a collection with the same name. Any page with a `menu` attribute in the collection is added to the dropdown menu.